### PR TITLE
🧹 Generic housekeeping

### DIFF
--- a/backend/TickManager.ts
+++ b/backend/TickManager.ts
@@ -1,6 +1,6 @@
 import logger from './logging/logger';
 import Timeout = NodeJS.Timeout;
-import Controller from './state/controller';
+import Controller from './state/Controller';
 
 const log = logger('tick');
 

--- a/backend/app.ts
+++ b/backend/app.ts
@@ -8,8 +8,8 @@ import { AddressInfo } from 'net';
 import State from './state';
 import { getDataProvider } from './data/DataProviderService';
 import minimist from 'minimist';
-import DataDragon from './data/league/datadragon';
-import Controller from './state/controller';
+import DataDragon from './data/league/DataDragon';
+import Controller from './state/Controller';
 import GlobalContext from './GlobalContext';
 import './Console';
 

--- a/backend/data/league/LeagueDataProviderService.ts
+++ b/backend/data/league/LeagueDataProviderService.ts
@@ -127,7 +127,7 @@ class LeagueDataProviderService extends EventEmitter
   }
 
   onLeagueConnected(e: ConnectionInfo): void {
-    log.info('LeagueClient connected');
+    log.info(`LeagueClient connected: ${JSON.stringify(e)}`);
     this.connectionInfo = e;
     this.requestConfig.username = this.connectionInfo.username;
     this.requestConfig.password = this.connectionInfo.password;

--- a/backend/state/Controller.ts
+++ b/backend/state/Controller.ts
@@ -2,8 +2,8 @@ import { EventEmitter } from "events";
 import convertState from "./converter";
 import { CurrentState } from "../data/CurrentState";
 import DataProviderService from "../data/DataProviderService";
-import State from "./state";
-import DataDragon from "../data/league/datadragon";
+import State from "./State";
+import DataDragon from "../data/league/DataDragon";
 import logger from "../logging/logger";
 
 const log = logger("Controller");

--- a/backend/state/converter.ts
+++ b/backend/state/converter.ts
@@ -1,7 +1,7 @@
 import {Action, ActionType, Cell, Timer} from '../types/lcu';
 import {Ban, Champion, Pick, Team} from '../types/dto';
 import DataProviderService from '../data/DataProviderService';
-import DataDragon from '../data/league/datadragon';
+import DataDragon from '../data/league/DataDragon';
 import {CurrentState} from '../data/CurrentState';
 import RecordingDatapoint from '../recording/RecordingDatapoint';
 

--- a/backend/state/index.ts
+++ b/backend/state/index.ts
@@ -1,3 +1,3 @@
-import state from './state';
+import State from './State';
 
-export default state;
+export default State;

--- a/layouts/layout-volu-europe/scripts/start.js
+++ b/layouts/layout-volu-europe/scripts/start.js
@@ -127,7 +127,9 @@ checkBrowsers(paths.appPath, isInteractive)
       }
 
       console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
+      if (process.env.NOOPEN !== 'true') {
+        openBrowser(urls.localUrlForBrowser);
+      }
     });
 
     ['SIGINT', 'SIGTERM'].forEach(function(sig) {

--- a/layouts/layout-volu-europe/src/App.jsx
+++ b/layouts/layout-volu-europe/src/App.jsx
@@ -31,6 +31,7 @@ function App() {
         });
 
         Window.PB.on('heartbeat', hb => {
+            console.info(`Got new config: ${JSON.stringify(hb.config)}`);
             setConfig(hb.config);
         });
 
@@ -38,12 +39,22 @@ function App() {
     }, []);
 
     console.log(globalState);
+    console.log(config);
 
-    return (
-        <div className="App">
-            <Overlay state={convertState(globalState, Window.PB.backend)} config={config}/>
-        </div>
-    );
+    if (config) {
+
+        return (
+            <div className="App">
+                <Overlay state={convertState(globalState, Window.PB.backend)} config={config}/>
+            </div>
+        );
+    } else {
+        return (
+            <div>
+                Loading config...
+            </div>
+        )
+    }
 }
 
 export default App;

--- a/layouts/layout-volu-europe/src/europe/Overlay.jsx
+++ b/layouts/layout-volu-europe/src/europe/Overlay.jsx
@@ -47,15 +47,15 @@ export default class Overlay extends React.Component {
         console.log(state);
 
         const renderBans = (teamState) =>{
-            const list =  teamState.bans.map(ban => <Ban {...ban} />);
-            list.splice(3, 0, <div className={css.Spacing} />);
+            const list =  teamState.bans.map((ban, idx) => <Ban key={`ban-${idx}`} {...ban} />);
+            list.splice(3, 0, <div key="ban-spacer" className={css.Spacing} />);
             return <div className={cx(css.BansBox)}>{list}</div>;
         };
 
         const renderTeam = (teamName, teamConfig, teamState) => (
             <div className={cx(css.Team, teamName)}>
                 <div className={cx(css.Picks)}>
-                    {teamState.picks.map(pick => <Pick config={this.props.config} {...pick} />)}
+                    {teamState.picks.map((pick, idx) => <Pick key={`pick-${idx}`} config={this.props.config} {...pick} />)}
                 </div>
                 <div className={css.BansWrapper}>
                     <div className={cx(css.Bans, {[css.WithScore]: config.frontend.scoreEnabled})}>
@@ -99,7 +99,7 @@ export default class Overlay extends React.Component {
                             <div className={cx(css.Background, css.Blue)} />
                             <div className={cx(css.Background, css.Red)} />
                             {state.timer < 100 && <div className={cx(css.TimerChars)}>
-                                {state.timer.toString().split('').map(char => <div
+                                {state.timer.toString().split('').map((char, idx) => <div key={`div-${idx}`}
                                     className={cx(css.TimerChar)}>{char}</div>)}
                             </div>}
                             {state.timer >= 100 && <div className={cx(css.TimerChars)}>


### PR DESCRIPTION
Hello there 👋

we would like to contribute some QoS improvements to the project which we've collected in this one PR since they are quite insignificant on their own:  

Firstly, we've changed some imports so their casing does not cause case-sensitive execution environments to fail compilation.  

Secondly, we've added a environment variable ``NOOPEN=true`` to the EU-Layout which skips the ``openBrowser(...)``-call when starting the EU layout and can be used if desired.  
When debugging or using the overlay, some of us felt a little annoyed by the overlay opening the browser on each start. This way, users can specifically opt out of the default behavior and take care of the required page refresh themselves.

Lastly, we've addressed some browser errors/warnings by adding some null checks here and there and providing some ``key``s to React. Basically, we avoid calling the render functions when objects aren't already initialized. This prevents some confusion from happening with users who know to look at their browser console but don't know enough to see that the errors are temporary.  

Best regards,

Magnus